### PR TITLE
Pre commit hook for coding styles commands

### DIFF
--- a/jsSupportFiles/.eslintrc
+++ b/jsSupportFiles/.eslintrc
@@ -1,0 +1,198 @@
+{
+   "rules": {
+      "no-compare-neg-zero": 2,
+      "no-cond-assign": 0,
+      "no-constant-condition": 2,
+      "no-control-regex": 2,
+      "no-debugger": 2,
+      "no-dupe-args": 2,
+      "no-dupe-keys": 2,
+      "no-duplicate-case": 2,
+      "no-empty": 2,
+      "no-empty-character-class": 2,
+      "no-ex-assign": 2,
+      "no-extra-boolean-cast": 2,
+      "no-extra-parens": 0,
+      "no-extra-semi": 2,
+      "no-func-assign": 2,
+      "no-inner-declarations": 2,
+      "no-invalid-regexp": 2,
+      "no-irregular-whitespace": 2,
+      "no-obj-calls": 2,
+      "no-prototype-builtins": 0,
+      "no-regex-spaces": 2,
+      "no-sparse-arrays": 2,
+      "no-template-curly-in-string": 0,
+      "no-unexpected-multiline": 2,
+      "no-unreachable": 2,
+      "no-unsafe-finally": 2,
+      "no-unsafe-negation": 0,
+      "use-isnan": 2,
+      "valid-jsdoc": [
+         0,
+         {
+            "requireParamDescription": false,
+            "requireReturnDescription": false,
+            "requireReturn": false,
+            "prefer": {
+               "returns": "return"
+            }
+         }
+      ],
+      "valid-typeof": 2,
+      "curly": [
+         2,
+         "multi-line"
+      ],
+      "guard-for-in": 0,
+      "no-caller": 2,
+      "no-case-declarations": 2,
+      "no-empty-pattern": 2,
+      "no-extend-native": 2,
+      "no-extra-bind": 2,
+      "no-fallthrough": 2,
+      "no-invalid-this": 1,
+      "no-multi-spaces": 2,
+      "no-multi-str": 2,
+      "no-new-wrappers": 2,
+      "no-octal": 2,
+      "no-redeclare": 2,
+      "no-self-assign": 2,
+      "no-throw-literal": 2,
+      "no-unused-labels": 2,
+      "no-with": 2,
+      "no-delete-var": 2,
+      "no-undef": 1,
+      "no-unused-vars": [
+         1,
+         {
+            "args": "none"
+         }
+      ],
+      "array-bracket-newline": 0,
+      "array-bracket-spacing": [
+         2,
+         "never"
+      ],
+      "array-element-newline": 0,
+      "block-spacing": [
+         2,
+         "never"
+      ],
+      "brace-style": 2,
+      "camelcase": [
+         2,
+         {
+            "properties": "never"
+         }
+      ],
+      "comma-dangle": [
+         0,
+         "always-multiline"
+      ],
+      "comma-spacing": 2,
+      "comma-style": 2,
+      "computed-property-spacing": 2,
+      "eol-last": 2,
+      "func-call-spacing": 2,
+      "key-spacing": 2,
+      "keyword-spacing": 2,
+      "linebreak-style": 2,
+      "max-len": [
+         1,
+         {
+            "code": 200,
+            "tabWidth": 2,
+            "ignoreUrls": true,
+            "ignorePattern": "^goog.(module|require)"
+         }
+      ],
+      "new-cap": 2,
+      "no-array-constructor": 2,
+      "no-mixed-spaces-and-tabs": 2,
+      "no-multiple-empty-lines": [
+         2,
+         {
+            "max": 2
+         }
+      ],
+      "no-new-object": 2,
+      "no-tabs": 2,
+      "no-trailing-spaces": 2,
+      "one-var": [
+         2,
+         {
+            "var": "never",
+            "let": "never",
+            "const": "never"
+         }
+      ],
+      "padded-blocks": [
+         2,
+         "never"
+      ],
+      "quote-props": [
+         0,
+         "consistent"
+      ],
+      "quotes": [
+         2,
+         "single",
+         {
+            "allowTemplateLiterals": true
+         }
+      ],
+      "require-jsdoc": [
+         0,
+         {
+            "require": {
+               "FunctionDeclaration": true,
+               "MethodDefinition": true,
+               "ClassDeclaration": true
+            }
+         }
+      ],
+      "semi": 2,
+      "semi-spacing": 2,
+      "space-before-blocks": 2,
+      "space-before-function-paren": [
+         2,
+         {
+            "asyncArrow": "always",
+            "anonymous": "never",
+            "named": "never"
+         }
+      ],
+      "spaced-comment": [
+         2,
+         "always"
+      ],
+      "switch-colon-spacing": 2,
+      "arrow-parens": [
+         0,
+         "always"
+      ],
+      "constructor-super": 2,
+      "generator-star-spacing": [
+         2,
+         "after"
+      ],
+      "no-const-assign": 0,
+      "no-dupe-class-members": 0,
+      "no-new-symbol": 2,
+      "no-this-before-super": 2,
+      "no-var": 2,
+      "prefer-rest-params": 2,
+      "prefer-spread": 2,
+      "require-yield": 2,
+      "rest-spread-spacing": 2,
+      "yield-star-spacing": [
+         2,
+         "after"
+      ]
+   },
+   "parserOptions": {
+      "ecmaVersion": 8
+   },
+   "env": { "node": true }
+}

--- a/jsSupportFiles/install-precommit-commands.js
+++ b/jsSupportFiles/install-precommit-commands.js
@@ -1,0 +1,83 @@
+/**
+ * The original contributor <shidhin.cr@namshi.com>
+ *
+ * Code formatting is one of the common issues we faced in most of our reviews.
+ * Though, we used to follow some coding formats, it was not strictly enforced. Moreover, it was difficult to set it up without editors/build-tools.
+ *
+ * Prettier ( from Facebook guys ), is a wonderful tool to format the codes.
+ * I have set it up in my editor and really saved a lot of time fixing the formatting issues.
+ * It will be a good option if we can set it up in our repositories ( though pre-commit scripts/hook ) so that we don’t need to worry about the code-formatting issues anymore.
+ * I have created a small helper code here for easily adding the pre-commit scripts to any repo.
+ *
+ * https://github.com/namshi/coding-standards/blob/master/jsSupportFiles/install-precommit-commands.js
+ *
+ * You can also include the eslint file simply by download it from:
+ *  wget https://raw.githubusercontent.com/namshi/coding-standards/master/jsSupportFiles/.eslintrc
+ *
+ * So, we just need to call this in any repo by this command:
+ *
+ * curl https://raw.githubusercontent.com/namshi/coding-standards/master/jsSupportFiles/install-precommit-commands.js | node
+ *
+ * Running the above command will modify the package.json and install the required dependencies.
+ *
+ * It will also add the following npm scripts:
+ * `lint-staged` => This is the actual pre-commit scripts. Whenever you try to commit,
+ *  it will take the staged files, run eslint and prettier on it, and commit the files.
+ *
+ * But if we want to format the existing files, we can run :
+ * 'eslint YOUR_FILE_OR_DIR'
+ * 'prettier YOUR_FILE_OR_DIR'
+ */
+
+const prettierOptions = '--single-quote --jsx-bracket-same-line --trailing-comma es5';
+
+const generateBlocks = (pkg, keys) => {
+  keys.forEach(key => {
+    if (!pkg[key]) pkg[key] = {};
+  });
+};
+
+const _message = message => {
+  console.log('-> ', message);
+};
+
+try {
+  let pkg = require('./package.json');
+  let fs = require('fs');
+  let exec = require('child_process').exec;
+  let isYarn = fs.existsSync('./yarn.lock');
+  let args = process.argv.slice(2);
+  if (!isYarn) {
+    isYarn = args.indexOf('--npm') === -1;
+  }
+  generateBlocks(pkg, ['devDependencies', 'scripts', 'lint-staged', 'husky']);
+  _message('Configuring pre-commit ...');
+  pkg.devDependencies['lint-staged'] = '*';
+  pkg.devDependencies['husky'] = 'next';
+  pkg.devDependencies['eslint'] = '*';
+  pkg.devDependencies['prettier'] = '*';
+  pkg.scripts.eslint = `eslint --fix`;
+  pkg.scripts.prettier = `prettier --write ${prettierOptions} `;
+  pkg['lint-staged']['*.js'] = ['eslint', 'prettier', 'git add'];
+  pkg['husky']['hooks'] = {'pre-commit': 'lint-staged'};
+  _message('Writing package.json ...');
+  fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2));
+
+  if (isYarn) {
+    _message('Installing dependencies using YARN...');
+    exec('yarn', { shell: '/bin/sh' }, (err, stdout, stderr) => {
+      console.log('Installed the dependencies', stdout, stderr);
+    });
+  } else {
+    _message('Installing dependencies using NPM...');
+    exec(
+      'npm install --only=dev',
+      { shell: '/bin/sh' },
+      (err, stdout, stderr) => {
+        console.log('Installed the dependencies', stdout, stderr);
+      }
+    );
+  }
+} catch (err) {
+  _message('Error occured :: ', err.toString());
+}


### PR DESCRIPTION
#### I have added eslint coding style rules drived from [google code style](https://github.com/google/eslint-config-google/blob/master/index.js) and fix it to be [prettier](https://github.com/prettier/prettier) compatible 

### _So you only need to do:_
```sh
 cd YOUR_REPO_DIRECTORY

 wget https://raw.githubusercontent.com/namshi/coding-standards/master/jsSupportFiles/.eslintrc

 curl https://raw.githubusercontent.com/namshi/coding-standards/master/jsSupportFiles/install-precommit-commands.js | node
```

#### Running the above command will modify the package.json and install the required dependencies. It will also add the following `npm` scripts:

`lint-staged` => This is the actual pre-commit scripts. Whenever you try to commit, it will take the staged files, run eslint and prettier on it, and commit the files.
 
#### But if we want to format the existing files, we can run :

`npm run eslint YOUR_FILE_OR_DIR`
`npm run prettier YOUR_FILE_OR_DIR`
 
### Credit:
Thanks to @shidhincr, we have a very simple way to have code styling fix on pre-commit in this gist
https://gist.github.com/shidhincr/3816f8ed5f03c10405892641e60f94d6
